### PR TITLE
README.md: broken urls of "Pharo for the Enterprise"'s pdf and html

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Metacello new
 Documentation
 -------------
 ### Pharo for the enterprise book
-Voyage is part of the upcoming "Pharo for the Enterprise 2" book, and Johan Fabry (along with Damien Cassou) has written a nice chapter on it: [HTML](https://ci.inria.fr/pharo-contribution/job/EnterprisePharoBook/ws/Voyage/Voyage.html) / [PDF](https://ci.inria.fr/pharo-contribution/job/EnterprisePharoBook/ws/Voyage/Voyage.pdf)
+Voyage is part of the upcoming "Pharo for the Enterprise 2" book, and Johan Fabry (along with Damien Cassou) has written a nice chapter on it: [HTML](https://ci.inria.fr/pharo-contribution/job/EnterprisePharoBook/ws/book-result/Voyage/Voyage.html) / [PDF](https://ci.inria.fr/pharo-contribution/job/EnterprisePharoBook/ws/book-result/Voyage/Voyage.pdf)
 
 ### Others
 - http://smallworks.eu/web/blog/2013-06-14-voyage-the-adventure


### PR DESCRIPTION
Just inserted "book-result/" to fix the urls of "Pharo for the Enterprise"'s pdf and html
